### PR TITLE
add BottomNavigationBar

### DIFF
--- a/lib/page/root/top_page.dart
+++ b/lib/page/root/top_page.dart
@@ -33,6 +33,7 @@ class _TopHomePageState extends State<TopHomePage> with SingleTickerProviderStat
   late TabController _controller;
   final List<TabInfo> _tabs = tabsInfo;
   int _selectedYear = tabsInfo.last.year;
+  int selectedPage = 0;
 
   @override
   void initState() {
@@ -80,6 +81,20 @@ class _TopHomePageState extends State<TopHomePage> with SingleTickerProviderStat
           body: TabBarView(
             children: _tabs.map((tab) => tab.widget).toList(),
             controller: _controller,
+          ),
+          bottomNavigationBar: BottomNavigationBar(
+            items: const [
+              BottomNavigationBarItem(icon: Icon(Icons.home_sharp, size: 20), activeIcon: Icon(Icons.home_rounded, size: 30), label: 'ホーム'),
+              BottomNavigationBarItem(icon: Icon(Icons.history_sharp, size: 20), activeIcon: Icon(Icons.history_rounded, size: 30), label: '履歴'),
+              BottomNavigationBarItem(icon: Icon(Icons.favorite_sharp, size: 20), activeIcon: Icon(Icons.favorite_rounded, size: 30), label: 'お気に入り'),
+            ],
+            elevation: 5.0,
+            currentIndex: selectedPage,
+            onTap: (index){
+              setState(() {
+                selectedPage = index;
+              });
+            },
           )
       ),
     );


### PR DESCRIPTION
# したこと(Overview)
BottomNavigationBar の追加。[bottom tab を利用したい #63](https://github.com/4geru/flutter_academy_final/issues/63)
ページ遷移等の実装は後続でする。

# 挙動(Behavior)
<img width="445" alt="スクリーンショット 2022-05-08 5 30 58" src="https://user-images.githubusercontent.com/8898432/167270795-ca8a5549-b532-4816-8b63-f757f32ba69c.png">

