### PR TITLE
implement seasons on detail page

### DIFF
--- a/lib/model/simple_tv_object.dart
+++ b/lib/model/simple_tv_object.dart
@@ -19,7 +19,7 @@ class SimpleTvObject {
       id: json['id'],
       originalName: json['originalName'],
       posterPath: json['posterPath'],
-      timestamp: json['timestamp']
+      timestamp: DateTime.parse(json['timestamp'])
     );
   }
 

--- a/lib/model/tv_detail_result_object.dart
+++ b/lib/model/tv_detail_result_object.dart
@@ -224,25 +224,25 @@ class ProductionCountry {
 
 class Season {
   Season({
-    required this.airDate,
+    this.airDate,
     this.episodeCount,
     this.id,
     required this.name,
     this.overview,
-    required this.posterPath,
+    this.posterPath,
     this.seasonNumber,
   });
 
-  DateTime airDate;
+  DateTime? airDate;
   int? episodeCount;
   int? id;
   String name;
   String? overview;
-  String posterPath;
+  String? posterPath;
   int? seasonNumber;
 
   factory Season.fromJson(Map<String, dynamic> json) => Season(
-    airDate: DateTime.parse(json["air_date"]),
+    airDate: json["air_date"] != null ? DateTime.parse(json["air_date"]) : null,
     episodeCount: json["episode_count"],
     id: json["id"],
     name: json["name"],

--- a/lib/model/tv_detail_result_object.dart
+++ b/lib/model/tv_detail_result_object.dart
@@ -25,7 +25,7 @@ class TvDetailResultObject {
     this.posterPath,
     this.productionCompanies,
     this.productionCountries,
-    this.seasons,
+    required this.seasons,
     this.spokenLanguages,
     this.status,
     this.tagline,
@@ -59,7 +59,7 @@ class TvDetailResultObject {
   String? posterPath;
   List<Network>? productionCompanies;
   List<ProductionCountry>? productionCountries;
-  List<Season>? seasons;
+  List<Season> seasons;
   List<SpokenLanguage>? spokenLanguages;
   String? status;
   String? tagline;

--- a/lib/model/tv_detail_result_object.dart
+++ b/lib/model/tv_detail_result_object.dart
@@ -224,25 +224,25 @@ class ProductionCountry {
 
 class Season {
   Season({
-    this.airDate,
+    required this.airDate,
     this.episodeCount,
     this.id,
-    this.name,
+    required this.name,
     this.overview,
-    this.posterPath,
+    required this.posterPath,
     this.seasonNumber,
   });
 
-  DateTime? airDate;
+  DateTime airDate;
   int? episodeCount;
   int? id;
-  String? name;
+  String name;
   String? overview;
-  String? posterPath;
+  String posterPath;
   int? seasonNumber;
 
   factory Season.fromJson(Map<String, dynamic> json) => Season(
-    airDate: json["air_date"] != null ? DateTime.parse(json["air_date"]) : null,
+    airDate: DateTime.parse(json["air_date"]),
     episodeCount: json["episode_count"],
     id: json["id"],
     name: json["name"],

--- a/lib/page/details/components/seasons.dart
+++ b/lib/page/details/components/seasons.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_study_day7/model/tv_detail_result_object.dart';
+import 'package:flutter_study_day7/theme.dart';
+
+class Seasons extends StatefulWidget {
+  int year;
+  List<Season> seasons;
+  Seasons({Key? key, required this.seasons, required this.year}) : super(key: key);
+
+  @override
+  State<Seasons> createState() => _SeasonsState();
+}
+
+class _SeasonsState extends State<Seasons> {
+  bool _openSeason = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Card(
+          child: ListTile(
+              title: const Text('シーズン'),
+              trailing: _openSeason ? Icon(Icons.arrow_drop_up) : Icon(Icons.arrow_drop_down),
+              onTap: () => setState(() =>_openSeason = !_openSeason)
+          ),
+        ),
+        if(_openSeason)
+          ...(widget.seasons ?? []).map((e) {
+            String openDate = "${e.airDate?.year}年${e.airDate?.month}月${e.airDate?.day}日";
+            return Card(
+              child: ListTile(
+                  leading: Image.network(
+                    'https://image.tmdb.org/t/p/w300/${e.posterPath}',
+                  ),
+                  title: Text(e.name),
+                  subtitle: Row(
+                      children: [
+                        if(
+                        widget.year == e.airDate?.year ||
+                            (e.airDate == null && widget.year != e.airDate?.year)
+                        ) const Icon(
+                          Icons.favorite,
+                          color: anyaSecondaryColor,
+                          size: 24.0,
+                          semanticLabel: 'Text to announce in accessibility modes',
+                        ),
+                        Text("${e.airDate != null ? openDate : ''}${e.episodeCount}話"),
+                      ]
+                  )
+              ),
+            );
+          }),
+      ],
+    );
+    // return ;
+  }
+}

--- a/lib/page/details/components/seasons.dart
+++ b/lib/page/details/components/seasons.dart
@@ -36,15 +36,13 @@ class _SeasonsState extends State<Seasons> {
                   title: Text(e.name),
                   subtitle: Row(
                       children: [
-                        if(
-                        widget.year == e.airDate?.year ||
-                            (e.airDate == null && widget.year != e.airDate?.year)
-                        ) const Icon(
-                          Icons.favorite,
-                          color: anyaSecondaryColor,
-                          size: 24.0,
-                          semanticLabel: 'Text to announce in accessibility modes',
-                        ),
+                        if(widget.year == e.airDate?.year)
+                          const Icon(
+                            Icons.favorite,
+                            color: anyaSecondaryColor,
+                            size: 24.0,
+                            semanticLabel: 'Text to announce in accessibility modes',
+                          ),
                         Text("${e.airDate != null ? openDate : ''}${e.episodeCount}話"),
                       ]
                   )

--- a/lib/page/details/detail_page.dart
+++ b/lib/page/details/detail_page.dart
@@ -30,7 +30,6 @@ class _DetailPageState extends State<DetailPage> {
     if(store.isLoading()) {
       return const LoadingComponent();
     }
-
     return Scaffold(
       body: SingleChildScrollView(child:
         Column(
@@ -42,19 +41,24 @@ class _DetailPageState extends State<DetailPage> {
             if(store.tvDetailResultObject?.overview != '') Overview(overview: store.tvDetailResultObject?.overview ?? ""),
             const Card(child: ListTile(title: Text('Season'))),
             ...(store.tvDetailResultObject?.seasons ?? []).map((e) {
+              String openDate = "${e.airDate?.year}年${e.airDate?.month}月${e.airDate?.day}日";
               return Card(
                 child: ListTile(
-                  selected: widget.argument.year == e.airDate.year,
                   leading: Image.network(
                     'https://image.tmdb.org/t/p/w300/${e.posterPath}',
                   ),
-                  title: Row(
+                  title: Text(e.name),
+                  subtitle: Row(
                     children: [
-                      Text(e.name),
-                      Text(" ${e.episodeCount}話", style: Theme.of(context).textTheme.caption)
-                    ],
-                  ),
-                  subtitle: Text("${e.airDate.year}年${e.airDate.month}月${e.airDate.day}日"),
+                      if(widget.argument.year == e.airDate?.year) const Icon(
+                        Icons.favorite,
+                        color: anyaSecondaryColor,
+                        size: 24.0,
+                        semanticLabel: 'Text to announce in accessibility modes',
+                      ),
+                      Text("${e.airDate != null ? openDate : ''}${e.episodeCount}話"),
+                    ]
+                  )
                 ),
               );
             }),

--- a/lib/page/details/detail_page.dart
+++ b/lib/page/details/detail_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_study_day7/page/details/components/back_drop_and_rating.
 import 'package:flutter_study_day7/page/details/components/cast_and_crew.dart';
 import 'package:flutter_study_day7/page/details/components/genres.dart';
 import 'package:flutter_study_day7/page/details/components/overview.dart';
+import 'package:flutter_study_day7/page/details/components/seasons.dart';
 import 'package:flutter_study_day7/page/details/components/title_duration_and_fav_btn.dart';
 import 'package:flutter_study_day7/page/details/hooks.dart';
 import 'package:flutter_study_day7/theme.dart';
@@ -21,7 +22,6 @@ class DetailPage extends StatefulWidget {
 
 class _DetailPageState extends State<DetailPage> {
   late UseDetailPage useDetailPage;
-  bool _openSeason = false;
 
   @override
   Widget build(BuildContext context) {
@@ -40,39 +40,7 @@ class _DetailPageState extends State<DetailPage> {
             TitleDurationAndFabBtn(tvDetailResultObject: store.tvDetailResultObject!),
             Genres(genres: store.tvDetailResultObject?.genres ?? []),
             if(store.tvDetailResultObject?.overview != '') Overview(overview: store.tvDetailResultObject?.overview ?? ""),
-            Card(
-              child: ListTile(
-                title: const Text('シーズン'),
-                trailing: _openSeason ? Icon(Icons.arrow_drop_up) : Icon(Icons.arrow_drop_down),
-                onTap: () => setState(() =>_openSeason = !_openSeason)
-              ),
-            ),
-            if(_openSeason)
-              ...(store.tvDetailResultObject?.seasons ?? []).map((e) {
-                String openDate = "${e.airDate?.year}年${e.airDate?.month}月${e.airDate?.day}日";
-                return Card(
-                  child: ListTile(
-                    leading: Image.network(
-                      'https://image.tmdb.org/t/p/w300/${e.posterPath}',
-                    ),
-                    title: Text(e.name),
-                    subtitle: Row(
-                      children: [
-                        if(
-                          widget.argument.year == e.airDate?.year ||
-                          (e.airDate == null && widget.argument.year != e.airDate?.year)
-                        ) const Icon(
-                          Icons.favorite,
-                          color: anyaSecondaryColor,
-                          size: 24.0,
-                          semanticLabel: 'Text to announce in accessibility modes',
-                        ),
-                        Text("${e.airDate != null ? openDate : ''}${e.episodeCount}話"),
-                      ]
-                    )
-                  ),
-                );
-              }),
+            if(store.tvDetailResultObject?.seasons != null) Seasons(seasons: store.tvDetailResultObject!.seasons!, year: widget.argument.year),
             CastAndCrew(casts: store.aggregateCreditObject!.casts ?? []),
           ],
         )

--- a/lib/page/details/detail_page.dart
+++ b/lib/page/details/detail_page.dart
@@ -21,6 +21,7 @@ class DetailPage extends StatefulWidget {
 
 class _DetailPageState extends State<DetailPage> {
   late UseDetailPage useDetailPage;
+  bool _openSeason = false;
 
   @override
   Widget build(BuildContext context) {
@@ -39,29 +40,39 @@ class _DetailPageState extends State<DetailPage> {
             TitleDurationAndFabBtn(tvDetailResultObject: store.tvDetailResultObject!),
             Genres(genres: store.tvDetailResultObject?.genres ?? []),
             if(store.tvDetailResultObject?.overview != '') Overview(overview: store.tvDetailResultObject?.overview ?? ""),
-            const Card(child: ListTile(title: Text('Season'))),
-            ...(store.tvDetailResultObject?.seasons ?? []).map((e) {
-              String openDate = "${e.airDate?.year}年${e.airDate?.month}月${e.airDate?.day}日";
-              return Card(
-                child: ListTile(
-                  leading: Image.network(
-                    'https://image.tmdb.org/t/p/w300/${e.posterPath}',
+            Card(
+              child: ListTile(
+                title: const Text('シーズン'),
+                trailing: _openSeason ? Icon(Icons.arrow_drop_up) : Icon(Icons.arrow_drop_down),
+                onTap: () => setState(() =>_openSeason = !_openSeason)
+              ),
+            ),
+            if(_openSeason)
+              ...(store.tvDetailResultObject?.seasons ?? []).map((e) {
+                String openDate = "${e.airDate?.year}年${e.airDate?.month}月${e.airDate?.day}日";
+                return Card(
+                  child: ListTile(
+                    leading: Image.network(
+                      'https://image.tmdb.org/t/p/w300/${e.posterPath}',
+                    ),
+                    title: Text(e.name),
+                    subtitle: Row(
+                      children: [
+                        if(
+                          widget.argument.year == e.airDate?.year ||
+                          (e.airDate == null && widget.argument.year != e.airDate?.year)
+                        ) const Icon(
+                          Icons.favorite,
+                          color: anyaSecondaryColor,
+                          size: 24.0,
+                          semanticLabel: 'Text to announce in accessibility modes',
+                        ),
+                        Text("${e.airDate != null ? openDate : ''}${e.episodeCount}話"),
+                      ]
+                    )
                   ),
-                  title: Text(e.name),
-                  subtitle: Row(
-                    children: [
-                      if(widget.argument.year == e.airDate?.year) const Icon(
-                        Icons.favorite,
-                        color: anyaSecondaryColor,
-                        size: 24.0,
-                        semanticLabel: 'Text to announce in accessibility modes',
-                      ),
-                      Text("${e.airDate != null ? openDate : ''}${e.episodeCount}話"),
-                    ]
-                  )
-                ),
-              );
-            }),
+                );
+              }),
             CastAndCrew(casts: store.aggregateCreditObject!.casts ?? []),
           ],
         )

--- a/lib/page/details/detail_page.dart
+++ b/lib/page/details/detail_page.dart
@@ -40,6 +40,24 @@ class _DetailPageState extends State<DetailPage> {
             TitleDurationAndFabBtn(tvDetailResultObject: store.tvDetailResultObject!),
             Genres(genres: store.tvDetailResultObject?.genres ?? []),
             if(store.tvDetailResultObject?.overview != '') Overview(overview: store.tvDetailResultObject?.overview ?? ""),
+            const Card(child: ListTile(title: Text('Season'))),
+            ...(store.tvDetailResultObject?.seasons ?? []).map((e) {
+              return Card(
+                child: ListTile(
+                  selected: widget.argument.year == e.airDate.year,
+                  leading: Image.network(
+                    'https://image.tmdb.org/t/p/w300/${e.posterPath}',
+                  ),
+                  title: Row(
+                    children: [
+                      Text(e.name),
+                      Text(" ${e.episodeCount}話", style: Theme.of(context).textTheme.caption)
+                    ],
+                  ),
+                  subtitle: Text("${e.airDate.year}年${e.airDate.month}月${e.airDate.day}日"),
+                ),
+              );
+            }),
             CastAndCrew(casts: store.aggregateCreditObject!.casts ?? []),
           ],
         )

--- a/lib/page/details/detail_page_argument.dart
+++ b/lib/page/details/detail_page_argument.dart
@@ -2,6 +2,6 @@ import 'package:flutter_study_day7/model/tv_list_result_object.dart';
 
 class DetailPageArgument {
   final int tvId;
-  final int? year;
-  DetailPageArgument({ required this.tvId, this.year });
+  final int year;
+  DetailPageArgument({ required this.tvId, required this.year });
 }


### PR DESCRIPTION
# したこと(Overview)

implemented: #85 

- シーズンのコンポーネントを作成した
- 指定した年数と同じ場合は、ハートのアイコンを出すようにした

# 挙動(Behavior)

https://user-images.githubusercontent.com/8898432/168427322-23d7c7fe-a547-4ba8-b49e-2fe1a41dfadb.mov


