### PR TITLE
display error container when not found

### DIFF
--- a/lib/components/error_image_container.dart
+++ b/lib/components/error_image_container.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+import '../theme.dart';
+
+class ErrorImageContainer extends StatelessWidget {
+  const ErrorImageContainer({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        width: double.infinity,
+        color: anyaSecondaryWhiteColor,
+        child: const Icon(Icons.error));
+  }
+}

--- a/lib/page/details/components/cast_card.dart
+++ b/lib/page/details/components/cast_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../components/error_image_container.dart';
 import '../../../model/aggregate_credit_object.dart';
 import '../../../theme.dart';
 
@@ -16,10 +17,17 @@ class CastCard extends StatelessWidget {
         child: Column(
           children: <Widget>[
             const SizedBox(height: anyaDefaultPadding / 2),
-            Container(
+            SizedBox(
               height: 100,
               child: Image.network(
                 'https://image.tmdb.org/t/p/w300/${cast.profilePath}',
+                errorBuilder: (
+                  context,
+                  error,
+                  stackTrace,
+                ) {
+                  return const ErrorImageContainer();
+                },
               ),
             ),
             const SizedBox(height: anyaDefaultPadding / 2),

--- a/lib/page/details/components/seasons.dart
+++ b/lib/page/details/components/seasons.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../components/error_image_container.dart';
 import '../../../data/repo/locale_provider.dart';
 import '../../../model/tv_detail_result_object.dart';
 import '../../../theme.dart';
@@ -40,6 +41,13 @@ class _SeasonsState extends State<Seasons> {
               child: ListTile(
                   leading: Image.network(
                     'https://image.tmdb.org/t/p/w300/${season.posterPath}',
+                    errorBuilder: (
+                      context,
+                      error,
+                      stackTrace,
+                    ) {
+                      return const ErrorImageContainer();
+                    },
                   ),
                   title: Text(season.name),
                   subtitle: Column(

--- a/lib/page/details/detail_page.dart
+++ b/lib/page/details/detail_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../components/loading.dart';
-import '../../data/repo/locale_provider.dart';
 import '../../theme.dart';
 import 'components/back_drop_and_rating.dart';
 import 'components/cast_and_crew.dart';


### PR DESCRIPTION
# したこと(Overview)
fixed: #89 

* 画像が見つからない場合に、error を表すコンポーネントを表示した


# 挙動(Behavior)
<img width="443" alt="image" src="https://user-images.githubusercontent.com/8898432/170604440-76c57165-a55a-48a8-a9d1-ce40d31a02ae.png">

